### PR TITLE
Use UriBuilder to allow specifying token in query string

### DIFF
--- a/AutotuneWeb/Controllers/HomeController.cs
+++ b/AutotuneWeb/Controllers/HomeController.cs
@@ -113,8 +113,11 @@ namespace AutotuneWeb.Controllers
 
         private bool TempBasalIncludesRateProperty(Uri url)
         {
-            var profileSwitchUrl = new Uri(url, "/api/v1/treatments.json?find[eventType][$eq]=Temp%20Basal&count=10");
-            var req = WebRequest.CreateHttp(profileSwitchUrl);
+            var queryString = "find[eventType][$eq]=Temp%20Basal&count=10";
+            var profileSwitchUrl = new UriBuilder(url);
+            profileSwitchUrl.Path = "/api/v1/treatments.json";
+            profileSwitchUrl.Query = profileSwitchUrl.Query.Length > 1 ? $"{profileSwitchUrl.Query}&{queryString}" : queryString;
+            var req = WebRequest.CreateHttp(profileSwitchUrl.Uri);
             using (var resp = req.GetResponse())
             using (var stream = resp.GetResponseStream())
             using (var reader = new StreamReader(stream))


### PR DESCRIPTION
Fixes #43. This may interest you, @eurenda

I did test this and it seems to work as intended. Note that I had to force `ViewBag.PreviousResults` to `false` so that I don't have to set up Azure Storage but that shouldn't really affect anything.